### PR TITLE
Removed csi-snapshotter and csi-resizer

### DIFF
--- a/datacore-csi-1.0.1.yaml
+++ b/datacore-csi-1.0.1.yaml
@@ -58,30 +58,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
-          args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.3.0
-          args:
-            - "--v=5"
-            - "--csi-address=$(ADDRESS)"
-            - "--csiTimeout=30s"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-ssy-plugin
           image: datacoresoftware/ssy-csi:1.01
           imagePullPolicy: Always


### PR DESCRIPTION
CDS-1288: Can I safely comment out the 2 containers that are known to not work after installing our CSI Plugin and if so why do we leave them in when they do not work?

Link: https://dcsw.atlassian.net/browse/CDS-1288

FIX: Removed csi-snapshotter and csi-resizer from datacore-csi-1.0.1.yaml

Tests done:
1. Deployment of CSI Plugin Pods
2. Deploying a PV
3. Connectivity with SSV using FE Ports


@mlatchmansingh @datacore-dshafie Please review. 